### PR TITLE
Fix: Update requirements for broader compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,13 +69,14 @@ multiprocess==0.70.16
 multitasking==0.0.11
 mypy-extensions==1.0.0
 nest-asyncio==1.6.0
-networkx==3.3
+networkx==3.2.1
 nltk==3.8.1
 notion-client==2.2.1
 numpy==1.26.4
 openai==1.23.6
 orjson==3.10.3
-packaging==24.0
+packaging==23.2
+# packaging==24.0
 pandas==2.2.2
 peewee==3.17.3
 pillow==10.3.0
@@ -125,7 +126,6 @@ tzdata==2024.1
 ujson==5.9.0
 urllib3==2.2.1
 uvicorn==0.29.0
-uvloop==0.19.0
 watchfiles==0.21.0
 webencodings==0.5.1
 websockets==12.0
@@ -133,3 +133,4 @@ wrapt==1.16.0
 xxhash==3.4.1
 yarl==1.9.4
 yfinance==0.2.38
+#uvloop==0.19.0


### PR DESCRIPTION
- Downgrade networkx to 3.2.1 for Python 3.9 compatibility.
- Comment out uvloop as it's not supported on Windows. Used watchfiles==0.21.0 Instead.
- Adjust packaging version to 23.2 to resolve streamlit conflict.