### PR TITLE
Fix typo in ARD.md: acheive -> achieve

### DIFF
--- a/prompts/ARD.md
+++ b/prompts/ARD.md
@@ -15,7 +15,7 @@ Keep the discussion conceptual rather than technical.
 
 Remember that users may provide unorganised thoughts as they brainstorm. Help them crystallize the goal of their Agent and the requirements through your questions and summaries.
 
-Cover key aspects Model i.e. LLMs, Tools, Memory, instructions (Voice, Behaviour, Guardrails, Policy, Backstory), goals, reasoning loop, feedback mechanism, input, output, Evals (success & termination condition, metrics), extra context if needed to acheive the goal, how to use tools, what's the input and output you are expecting from the agent and from it's tools. 
+Cover key aspects Model i.e. LLMs, Tools, Memory, instructions (Voice, Behaviour, Guardrails, Policy, Backstory), goals, reasoning loop, feedback mechanism, input, output, Evals (success & termination condition, metrics), extra context if needed to achieve the goal, how to use tools, what's the input and output you are expecting from the agent and from it's tools. 
 
 Important: Do not generate any code during this conversation. The goal is to understand and plan the Agent at a high level. Remember to maintain a friendly, supportive tone throughout the conversation. Speak plainly and clearly, avoiding unnecessary technical jargon. Your goal is to help the user refine and solidify their agent idea while providing valuable insights and recommendations at a conceptual level to generate the ARD.
 


### PR DESCRIPTION
Fixed a typo in `prompts/ARD.md` where "acheive" was misspelled as "acheive". Changed it to "achieve".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in documentation to improve clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->